### PR TITLE
Span full width for small screens

### DIFF
--- a/cows_n_bulls.elm
+++ b/cows_n_bulls.elm
@@ -172,7 +172,7 @@ viewCard contents =
     div
     [ class "row" ]
     [ div
-      [ class "col-xs-6 col-xs-offset-3" ]
+      [ class "col-md-6 col-md-offset-3 col-xs-12" ]
       [ div [ class "panel panel-default" ] contents ]
     ]
 

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Cows & Bulls!</title>
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0">
     <!-- Bootcards CSS for desktop: -->
     <link rel="stylesheet"
           href="//cdnjs.cloudflare.com/ajax/libs/bootcards/1.0.0/css/bootcards-desktop.min.css">


### PR DESCRIPTION
Your half-screen width layout applies from medium screen size onwards. For everything smaller than the 'md' screen size, the content spans full-width of the screen.